### PR TITLE
feat(auth): JWT + interceptor

### DIFF
--- a/backend/src/main/java/com/parqueando/api/controller/AuthController.java
+++ b/backend/src/main/java/com/parqueando/api/controller/AuthController.java
@@ -1,0 +1,74 @@
+package com.parqueando.api.controller;
+
+import com.parqueando.api.dto.auth.AuthResponse;
+import com.parqueando.api.dto.auth.LoginRequest;
+import com.parqueando.api.dto.auth.MeResponse;
+import com.parqueando.api.dto.auth.RegisterRequest;
+import com.parqueando.api.dto.auth.RegisterResponse;
+import com.parqueando.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+  private final AuthService authService;
+
+  public AuthController(AuthService authService) {
+    this.authService = authService;
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<RegisterResponse> register(@Valid @RequestBody RegisterRequest req) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(authService.register(req));
+  }
+
+  @PostMapping("/login")
+  public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest req) {
+    return ResponseEntity.ok(authService.login(req));
+  }
+
+  // Nuevo endpoint protegido
+  @GetMapping("/me")
+  public ResponseEntity<MeResponse> me(Authentication authentication) {
+
+    String subject = authentication.getName(); // tu sub = idUsuario
+
+    // authorities
+    List<String> authorities = authentication.getAuthorities().stream()
+        .map(GrantedAuthority::getAuthority)
+        .toList();
+
+    // claims vienen del filtro (authToken.setDetails(claims))
+    String correo = null;
+    String rol = null;
+
+    Object details = authentication.getDetails();
+    if (details instanceof Map<?, ?> map) {
+      Object c = map.get("correo");
+      Object r = map.get("rol");
+      correo = (c != null) ? String.valueOf(c) : null;
+      rol = (r != null) ? String.valueOf(r) : null;
+    }
+
+    // fallback si no vino rol
+    if (rol == null) {
+      rol = authorities.stream()
+          .filter(a -> a.startsWith("ROLE_"))
+          .map(a -> a.substring(5))
+          .findFirst()
+          .orElse("CONDUCTOR");
+    }
+
+    return ResponseEntity.ok(new MeResponse(subject, correo, rol, authorities));
+  }
+}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/AuthResponse.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/AuthResponse.java
@@ -1,0 +1,11 @@
+package com.parqueando.api.dto.auth;
+
+public record AuthResponse(
+  boolean ok,
+  String token,
+  UsuarioResponse usuario
+) {
+  public static AuthResponse ok(String token, UsuarioResponse usuario) {
+    return new AuthResponse(true, token, usuario);
+  }
+}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/LoginRequest.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.parqueando.api.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+  @NotBlank @Email String correo,
+  @NotBlank String password
+) {}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/MeResponse.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/MeResponse.java
@@ -1,0 +1,10 @@
+package com.parqueando.api.dto.auth;
+
+import java.util.List;
+
+public record MeResponse(
+  String subject,
+  String correo,
+  String rol,
+  List<String> authorities
+) {}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/RegisterRequest.java
@@ -1,0 +1,33 @@
+package com.parqueando.api.dto.auth;
+
+import com.parqueando.domain.enums.RolPrincipal;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+
+  @NotBlank @Size(max = 100)
+  String nombres,
+
+  @NotBlank @Size(max = 100)
+  String apellidos,
+
+  @NotBlank @Email @Size(max = 150)
+  String correo,
+
+  @NotBlank @Size(min = 6, max = 72)
+  String password,
+
+  @Size(max = 20)
+  String telefono,
+
+  @Schema(
+      description = "Rol del usuario. Si no se envía, será CONDUCTOR",
+      example = "CONDUCTOR",
+      allowableValues = {"CONDUCTOR", "PROPIETARIO", "ADMIN"}
+  )
+  RolPrincipal rolPrincipal
+
+) {}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/RegisterResponse.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/RegisterResponse.java
@@ -1,0 +1,11 @@
+package com.parqueando.api.dto.auth;
+
+public record RegisterResponse(
+    boolean ok,
+    String mensaje,
+    Long uid
+) {
+    public static RegisterResponse success(Long uid) {
+        return new RegisterResponse(true, "Usuario creado exitosamente", uid);
+    }
+}

--- a/backend/src/main/java/com/parqueando/api/dto/auth/UsuarioResponse.java
+++ b/backend/src/main/java/com/parqueando/api/dto/auth/UsuarioResponse.java
@@ -1,0 +1,9 @@
+package com.parqueando.api.dto.auth;
+
+public record UsuarioResponse(
+  Long uid,
+  String nombre,
+  String email,
+  String telefono,
+  String foto
+) {}

--- a/backend/src/main/java/com/parqueando/security/JwtAuthFilter.java
+++ b/backend/src/main/java/com/parqueando/security/JwtAuthFilter.java
@@ -1,0 +1,85 @@
+package com.parqueando.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+  private final JwtService jwtService;
+
+  public JwtAuthFilter(JwtService jwtService) {
+    this.jwtService = jwtService;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain
+  ) throws ServletException, IOException {
+
+    // Si ya hay autenticación, no reprocesar
+    if (SecurityContextHolder.getContext().getAuthentication() != null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String auth = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    // 1) Si no hay Bearer token => NO hacemos nada (permitAll funciona normal)
+    if (!StringUtils.hasText(auth) || !auth.startsWith("Bearer ")) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    String token = auth.substring(7);
+
+    try {
+      // 2) Extraer subject y claims usando TU JwtService
+      String subject = jwtService.getSubject(token); // en tu caso: idUsuario (string)
+      Map<String, Object> claims = jwtService.getClaims(token);
+
+      // 3) Rol por defecto si no viene en claims
+      String rol = String.valueOf(claims.getOrDefault("rol", "CONDUCTOR"));
+
+      // 4) Crear Authentication
+      UsernamePasswordAuthenticationToken authToken =
+          new UsernamePasswordAuthenticationToken(
+              subject,
+              null,
+              List.of(new SimpleGrantedAuthority("ROLE_" + rol))
+          );
+
+      // ✅ Guardar TODOS los claims en details para /api/auth/me (correo, rol, etc.)
+      authToken.setDetails(claims);
+
+      // (opcional) si prefieres mantener también detalles de request, usa WebAuthenticationDetailsSource
+      // authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+      SecurityContextHolder.getContext().setAuthentication(authToken);
+
+      filterChain.doFilter(request, response);
+
+    } catch (Exception ex) {
+      // Si venía token pero es inválido / expirado / firma mala => 401
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.setContentType("application/json");
+      response.getWriter().write("{\"message\":\"Token inválido o expirado\"}");
+    }
+  }
+}

--- a/backend/src/main/java/com/parqueando/security/JwtService.java
+++ b/backend/src/main/java/com/parqueando/security/JwtService.java
@@ -1,0 +1,73 @@
+package com.parqueando.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+
+@Service
+public class JwtService {
+
+  private final SecretKey key;
+  private final String issuer;
+  private final int expirationMinutes;
+
+  public JwtService(
+      @Value("${app.jwt.secret}") String secret,
+      @Value("${app.jwt.issuer:parqueando}") String issuer,
+      @Value("${app.jwt.expirationMinutes:180}") int expirationMinutes
+  ) {
+    String s = (secret == null ? "" : secret);
+
+    // Asegura mínimo 32 caracteres para HS256
+    if (s.length() < 32) {
+      s = (s + "0123456789abcdef0123456789abcdef").substring(0, 32);
+    }
+
+    this.key = Keys.hmacShaKeyFor(s.getBytes(StandardCharsets.UTF_8));
+    this.issuer = issuer;
+    this.expirationMinutes = expirationMinutes;
+  }
+
+  public String generateToken(String subject, Map<String, Object> claims) {
+    Instant now = Instant.now();
+
+    return Jwts.builder()
+      .issuer(issuer)
+      .subject(subject)
+      .claims(claims)
+      .issuedAt(Date.from(now))
+      .expiration(Date.from(now.plus(expirationMinutes, ChronoUnit.MINUTES)))
+      // fijamos algoritmo (jjwt 0.12.x)
+      .signWith(key, Jwts.SIG.HS256)
+      .compact();
+  }
+
+  public String getSubject(String token) {
+    return Jwts.parser()
+      .verifyWith(key)
+      .build()
+      .parseSignedClaims(token)
+      .getPayload()
+      .getSubject();
+  }
+
+  public Map<String, Object> getClaims(String token) {
+    Claims claims = Jwts.parser()
+      .verifyWith(key)
+      .build()
+      .parseSignedClaims(token)
+      .getPayload();
+
+    // Claims implementa Map, devolvemos como Map para no romper tu JwtAuthFilter
+    return claims;
+  }
+}

--- a/backend/src/main/java/com/parqueando/security/SecurityConfig.java
+++ b/backend/src/main/java/com/parqueando/security/SecurityConfig.java
@@ -1,0 +1,87 @@
+package com.parqueando.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class SecurityConfig {
+
+  private final JwtAuthFilter jwtAuthFilter;
+
+  public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+    this.jwtAuthFilter = jwtAuthFilter;
+  }
+
+  @Bean
+  PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  // ✅ CORS para Ionic/Angular
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+
+    // Orígenes permitidos (ajusta si usas otro host/puerto)
+    config.setAllowedOrigins(List.of(
+        "http://localhost:8100", // Ionic serve
+        "http://localhost:4200"  // Angular
+    ));
+
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
+    config.setExposedHeaders(List.of("Authorization"));
+    config.setAllowCredentials(true);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
+  }
+
+  @Bean
+  SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http
+      // ✅ Habilita CORS usando el bean CorsConfigurationSource
+      .cors(Customizer.withDefaults())
+
+      .csrf(csrf -> csrf.disable())
+
+      .sessionManagement(sm ->
+        sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+      )
+
+      .authorizeHttpRequests(auth -> auth
+        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+        .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+        .requestMatchers("/api/auth/me").authenticated()
+        .requestMatchers(HttpMethod.GET, "/api/parqueaderos/**").permitAll()
+        .anyRequest().authenticated()
+      )
+
+      .exceptionHandling(e -> e
+        .authenticationEntryPoint((req, res, ex) -> {
+          res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        })
+      );
+
+    http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}


### PR DESCRIPTION
## Descripción
Implementa autenticación con JWT y soporte en frontend para enviar el token.

## Issue relacionada
Closes #1

## Cambios principales
- Backend: endpoints register/login/me con JWT
- Frontend: interceptor para Authorization Bearer token + guard
- Docs: actualización de flujo de autenticación

## Evidencia
- [x] Commits descriptivos
- [x] Probado localmente
- [x] CI ejecuta build en PR